### PR TITLE
Actualizando a Python 3.8 en 2023

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 # Base image
-FROM python:alpine
+FROM python:3.8.0-alpine
 # Image propietary
 LABEL maintainer="Aurelio Vivas aurelio.vivas@correounivalle.edu.co"
 # Working directory inside the container
 WORKDIR /usr/src/app
+# Installing packages
+RUN apk add --no-cache gcc musl-dev
 # Copy the project into the container current workdir
 COPY . .
 # Installing requirements
-RUN apk add --no-cache gcc musl-dev
 RUN pip install --no-cache-dir -r ./api/requirements.txt
 
 # Informs Docker that the container listens on the specified network ports at runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN pip install --no-cache-dir -r ./api/requirements.txt
 # about which ports are intended to be published. To actually publish the port when running 
 # the container, use the -p flag on docker run to publish and map one or more ports, or the -P 
 # flag to publish all exposed ports and map them to to high-order ports.
-EXPOSE 5000
+EXPOSE 5001
 
 CMD ["/bin/sh", "entrypoint.sh"]

--- a/README.MD
+++ b/README.MD
@@ -100,7 +100,7 @@ Perform the following commands to build the **pragcc** image, then to run the **
 
 ```sh
 docker build -t pragcc .
-docker run -d -v ${PWD}:/usr/src/app --name pragcc -p 5001:5001 pragcc
+docker run -d -v ${PWD}:/usr/src/app --name pragcc -p 5000:5000 pragcc
 ```
 
 ## Known Issues

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,10 +5,10 @@ flask-restplus==0.10.1
 itsdangerous==0.24
 Jinja2==2.10
 jsonschema==2.6.0
-MarkupSafe==1.0
 pyaml==17.8.0
 python-dateutil==2.6.1
 pytz==2017.3
 PyYAML==3.12
 six==1.11.0
-Werkzeug==0.12.2
+Werkzeug==0.14.1
+markupsafe==2.0.1

--- a/pragcc/core/parallelizer.py
+++ b/pragcc/core/parallelizer.py
@@ -230,7 +230,7 @@ class OpenMP(BaseParallelizer):
 
             # If in the parallel directive properties is not present 
             # the scope property no insertions are performed
-            if scope is not '':
+            if scope != '':
                 directive_scope = self._code.get_for_loops_scope(function_name,scope)
                 if directive_scope:
                     begin, end = directive_scope
@@ -469,7 +469,7 @@ class OpenACC(BaseParallelizer):
             raw_pragma = self.get_raw_pragma('data',clauses)
 
             # Determining the scope of the data pragma
-            if scope is not '':
+            if scope != '':
                 directive_scope = self._code.get_for_loops_scope(function_name,scope)
 
                 if directive_scope:


### PR DESCRIPTION
De  la versión de Python 3.9 en adelante la librería 'collections' ya no incorpora varias estructuras de datos como  las listas Hash, Maps; entre otras sino que se localizan esas estructuras en el paquete 'collections.abc'. Se fijó entonces la versión del contenedor a Python 3.8. Ese es el cambio más dramático. 

Se hicieron algunos cambios en el  código, en esta nueva versión de Python no es válido preguntar por la cadena vacía como 'is not ""' sino que se debe usar el operador '!='. 

Se ajusto en el 'README.MD' que el puerto por donde escucha el aplicativo es el '5000' cuando se ejecuta con 'docker container run..'.